### PR TITLE
Ignore whitespace removal on nested chidren

### DIFF
--- a/PrettyMin.php
+++ b/PrettyMin.php
@@ -244,8 +244,21 @@ class PrettyMin
     protected function removeWhitespace() {
         // Retrieve all text nodes using XPath
         $x = new \DOMXPath($this->doc);
-        $nodeList = $x->query("//text()");
-        foreach($nodeList as $node) {
+
+        // Ignore child nodes where we need to preserve whitespace on ancestor
+        $x_filter = array_map(function ($nodeName) {
+            return "ancestor::$nodeName";
+        }, $this->options['keep_whitespace_in']);
+
+        $x_filter = implode(' or ', $x_filter);
+
+        if ($x_filter) {
+            $nodeList = $x->query("//*[not($x_filter)]/text()");
+        } else {
+            $nodeList = $x->query("//text()");
+        }
+
+        foreach ($nodeList as $node) {
             /** @var \DOMNode $node */
 
             if (in_array($node->parentNode->nodeName, $this->options['keep_whitespace_in'])) {

--- a/Tests/PrettyMinTest.php
+++ b/Tests/PrettyMinTest.php
@@ -136,4 +136,39 @@ HTML;
 
         $this->assertEquals($expected, $pm->saveHtml());
     }
+
+    public function testPre()
+    {
+        $pre = <<<HTML
+if test
+  do this
+endif
+    <code>
+    if test
+      do this
+    endif
+    </code>
+        <samp>
+        if test
+          do this
+        endif
+        </samp>
+            <kbd>
+              if test
+                do this
+              endif
+            </kbd>
+HTML;
+
+        $html = "<!DOCTYPE html><html><body><pre>{$pre}</pre></body></html>";
+
+        $pm = new PrettyMin();
+        $pm->load($html);
+        $pm->indent();
+
+        // Contents of the <pre> section needs to match perfectly
+        preg_match('#<pre>(.*)</pre>#ms', $pm->saveHtml(), $match);
+
+        $this->assertEquals(trim($pre), trim($match[1]));  // Trailing and leading whitespace is allowed to be different
+    }
 }


### PR DESCRIPTION
This PR fixes a bug where the whitespace contents of `<pre>` were not being preserved where the `<pre>` block contained a nested `<code>` block.  

Example:
```
<pre>
  <code>
if test
  do this
</code>
</pre>
```

Would be formatted as:
```
<pre>
  <code>if test  do this</code>
</pre>
```

The `keep_whitespace_in` will preserve whitespace in any matching nodes and *its descendents*.  

A unit test was added to check for this case.  